### PR TITLE
Manage FBO auto-clearing

### DIFF
--- a/include/ada/gl/fbo.h
+++ b/include/ada/gl/fbo.h
@@ -18,7 +18,7 @@ public:
     Fbo();
     virtual ~Fbo();
 
-    virtual void    allocate(const unsigned int _width, const unsigned int _height, FboType _type, TextureFilter _filter = LINEAR, TextureWrap _wrap = REPEAT);
+    virtual void    allocate(const unsigned int _width, const unsigned int _height, FboType _type, TextureFilter _filter = LINEAR, TextureWrap _wrap = REPEAT, bool autoclear = true);
     virtual void    bind();
     virtual void    unbind();
     
@@ -52,6 +52,8 @@ protected:
     bool    m_allocated;
     bool    m_binded;
     bool    m_depth;
+    
+    bool    m_autoclear;
 };
 
 }

--- a/include/ada/gl/fbo.h
+++ b/include/ada/gl/fbo.h
@@ -18,7 +18,7 @@ public:
     Fbo();
     virtual ~Fbo();
 
-    virtual void    allocate(const unsigned int _width, const unsigned int _height, FboType _type, TextureFilter _filter = LINEAR, TextureWrap _wrap = REPEAT, bool autoclear = true);
+    virtual void    allocate(const unsigned int _width, const unsigned int _height, FboType _type, TextureFilter _filter = LINEAR, TextureWrap _wrap = REPEAT, bool _autoclear = true);
     virtual void    bind();
     virtual void    unbind();
     

--- a/src/gl/fbo.cpp
+++ b/src/gl/fbo.cpp
@@ -51,12 +51,14 @@ Fbo::~Fbo() {
     }
 }
 
-void Fbo::allocate(const uint32_t _width, const uint32_t _height, FboType _type, TextureFilter _filter, TextureWrap _wrap) {
+void Fbo::allocate(const uint32_t _width, const uint32_t _height, FboType _type, TextureFilter _filter, TextureWrap _wrap, bool autoclear) {
     m_type = _type;
 
     bool color_texture = true;
     bool depth_texture = false;
-
+    
+    m_autoclear = autoclear;
+    
     switch(_type) {
         case COLOR_TEXTURE:
             m_depth = false;
@@ -236,10 +238,13 @@ void Fbo::bind() {
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depth_id, 0);
 
         #if !defined(__EMSCRIPTEN__)
-        if (m_depth)
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        else
-            glClear(GL_COLOR_BUFFER_BIT);
+        if (m_autoclear)
+        {
+            if (m_depth)
+                glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            else
+                glClear(GL_COLOR_BUFFER_BIT);
+        }
         #endif
 
         m_binded = true;

--- a/src/gl/fbo.cpp
+++ b/src/gl/fbo.cpp
@@ -51,13 +51,13 @@ Fbo::~Fbo() {
     }
 }
 
-void Fbo::allocate(const uint32_t _width, const uint32_t _height, FboType _type, TextureFilter _filter, TextureWrap _wrap, bool autoclear) {
+void Fbo::allocate(const uint32_t _width, const uint32_t _height, FboType _type, TextureFilter _filter, TextureWrap _wrap, bool _autoclear) {
     m_type = _type;
 
     bool color_texture = true;
     bool depth_texture = false;
     
-    m_autoclear = autoclear;
+    m_autoclear = _autoclear;
     
     switch(_type) {
         case COLOR_TEXTURE:

--- a/src/gl/fbo.cpp
+++ b/src/gl/fbo.cpp
@@ -238,8 +238,7 @@ void Fbo::bind() {
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depth_id, 0);
 
         #if !defined(__EMSCRIPTEN__)
-        if (m_autoclear)
-        {
+        if (m_autoclear) {
             if (m_depth)
                 glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             else


### PR DESCRIPTION
Add a micro optimization via new initializer option which manages the clearing of the FBO (now optional) on binding of the FBO.